### PR TITLE
enhancement:hamburger menu to toggle to 'X' on mobile

### DIFF
--- a/frontend/src/components/Shared/Navbar.jsx
+++ b/frontend/src/components/Shared/Navbar.jsx
@@ -96,9 +96,14 @@ const Navbar = () => {
           {/* Mobile Menu Button */}
           <div className="flex md:hidden">
             <button onClick={toggleMenu} className={`${buttonTextClass} focus:outline-none`}>
+              {isMenuOpen ? 
               <svg className="h-6 w-6" fill="none" stroke="black" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+              : <svg className="h-6 w-6" fill="none" stroke="black" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
               </svg>
+              }
             </button>
           </div>
         </div>


### PR DESCRIPTION
This PR enhances the mobile navigation experience by updating the hamburger menu icon to toggle between a three-line icon and an "X" when the navigation bar drops down. This makes it clearer for users when the menu is open and clickable to close.

Attached is a video showcasing the new behavior on mobile.

https://github.com/user-attachments/assets/266ea7d1-4e1b-46e7-8599-7845c90fca14



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced mobile navigation with conditional rendering of icons based on menu state.
	- Updated mobile menu appearance with improved background colors and shadow effects based on scroll state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->