### PR TITLE
Fix - Fixed Scroll View of Navigation Links

### DIFF
--- a/frontend/src/components/Pages/About.jsx
+++ b/frontend/src/components/Pages/About.jsx
@@ -1,6 +1,10 @@
 import bgpic from "../../assets/img/abt1.jpg";
+import React, { useEffect } from 'react';
 
 export default function About() {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
   return (
     <div id="about" className="relative w-full h-screen md:mt-28">
       <div

--- a/frontend/src/components/Pages/Boardgame.jsx
+++ b/frontend/src/components/Pages/Boardgame.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState , useEffect } from 'react';
 import board1 from "../../assets/Boardgames/board1.png";
 import board2 from "../../assets/Boardgames/board2.png";
 import board3 from "../../assets/Boardgames/board3.jpg";
@@ -162,7 +162,9 @@ export default function Boardgame() {
         },
     ];
     
-    
+    useEffect(() => {
+        window.scrollTo(0, 0);
+      }, []);
 
     return (
         <>

--- a/frontend/src/components/Pages/Event.jsx
+++ b/frontend/src/components/Pages/Event.jsx
@@ -111,6 +111,10 @@ export default function Event() {
     };
   }, []);
 
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   return (
     <>
       <div id="event" className="w-full h-fit bg-amber-100 md:overflow-hidden ">

--- a/frontend/src/components/Pages/Home.jsx
+++ b/frontend/src/components/Pages/Home.jsx
@@ -3,8 +3,12 @@ import Landing from "../ui/Landing";
 import ReviewCarousel from "../ui/ReviewCarousel";
 import FeedbackForm from "../ui/FeedbackForm";
 import About from "./About";
+import React, { useEffect } from 'react';
 
 export default function Home() {
+    useEffect(() => {
+        window.scrollTo(0, 0);
+      }, []);
     return (
         <div id="home" className="bg-[#FDF3C7]">
             <Landing />

--- a/frontend/src/components/Pages/Login.jsx
+++ b/frontend/src/components/Pages/Login.jsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import photo from "../../assets/login.png";
-import React, { useState } from "react";
+import React, { useState , useEffect } from "react";
 
 const Login = () => {
   const API_URL = process.env.VITE_BACKEND_URL || "http://localhost:3000";
@@ -40,6 +40,10 @@ const Login = () => {
       setIsLoading(false);
     }
   };
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   return (
     <div className="w-screen h-screen flex items-center justify-center pt-10">

--- a/frontend/src/components/Pages/Menu.jsx
+++ b/frontend/src/components/Pages/Menu.jsx
@@ -1,4 +1,4 @@
-import  { useState } from 'react';
+import  { useState , useEffect } from 'react';
 import { motion } from 'framer-motion';
 import Mybook from './MyBook';
 import TodaysSpecial from './TodaysSpecial';
@@ -27,6 +27,10 @@ function ParallaxImage() {
     x: mousePosition.x / 30,
     y: mousePosition.y / 30,
   };
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   return (
     <>

--- a/frontend/src/components/Pages/MyBook.jsx
+++ b/frontend/src/components/Pages/MyBook.jsx
@@ -42,6 +42,10 @@ function MyBook() {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
   return (
     <div style={BgTextureStyle} className=" mt-2 mb-20 overflow-hidden w-full h-full flex justify-center items-center ">
       <HTMLFlipBook

--- a/frontend/src/components/Pages/Notfound.jsx
+++ b/frontend/src/components/Pages/Notfound.jsx
@@ -1,6 +1,10 @@
 import Notfound from "../../assets/Menu_assets/Notfound.gif"
+import React, { useState , useEffect } from 'react';
 
 const NotFound = () => {
+    useEffect(() => {
+        window.scrollTo(0, 0);
+      }, []);
     return (
        <div>
          <div className="flex flex-col items-center justify-center h-screen">

--- a/frontend/src/components/Pages/Pages.jsx
+++ b/frontend/src/components/Pages/Pages.jsx
@@ -1,7 +1,10 @@
-import  { forwardRef } from "react";
 import PropTypes from "prop-types";
+import React, { useState , useEffect , forwardRef } from 'react';
 
 const Page = forwardRef((props, ref) => {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
   return (
     <div className="demoPage bg-white" ref={ref}>
       <div className="h-full">{props.children}</div>

--- a/frontend/src/components/Pages/Register.jsx
+++ b/frontend/src/components/Pages/Register.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState , useEffect } from "react";
 import pic from "../../assets/img/abt1.jpg";
 import pic2 from "../../assets/img/abt1.png";
 import pic3 from "../../assets/img/abt2.png";
@@ -32,6 +32,10 @@ export default function Register() {
       .then((data) => console.log(data))
       .catch((error) => console.log(error));
   };
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   return (
     <>

--- a/frontend/src/components/Pages/Signup.jsx
+++ b/frontend/src/components/Pages/Signup.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState , useEffect } from "react";
 import photo from "../../assets/login.png";
 
 const Signup = () => {
@@ -25,6 +25,10 @@ const Signup = () => {
         const result = await response.json();
         console.log(result);    
     };
+
+    useEffect(() => {
+      window.scrollTo(0, 0);
+    }, []);
 
   return (
     <div className="w-screen h-screen flex items-center justify-center pt-10">


### PR DESCRIPTION
To resolve the issue of incorrect scroll position when navigating between pages, I used **React's useEffect hook** to automatically scroll the window to the top whenever a new page loads, ensuring correct view positioning in all the components pages.
Now, it is working as desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented automatic scrolling to the top of the page when navigating to various components (About, Boardgame, Event, Home, Login, Menu, MyBook, Notfound, Pages, Register, Signup). 

These enhancements improve user experience by ensuring that users start at the top of the page when they load different sections of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->