### PR TITLE
fix: Arrow Buttons Visible at Carousel Start and End Positions

### DIFF
--- a/frontend/src/components/ui/ReviewCarousel.jsx
+++ b/frontend/src/components/ui/ReviewCarousel.jsx
@@ -153,25 +153,29 @@ const ReviewCarousel = () => {
         // whileHover is a framer specific attribute
         // It displaces buttons by 10px on hover for that nice slide animation
         }
-        <motion.button
-          id="next"
-          className=" absolute top-[40%] text-green-900 bg-none border-none text-6xl font-mono font-bold opacity-80 transition-opacity z-10 right-[50px] max-sm:text-white max-sm:text-2xl max-sm:right-2"
-          onClick={() =>
-            setActive((prev) => (prev + 1 < items.length ? prev + 1 : prev))
-          }
-          whileHover={{ x: 10, color: '#00B2CA', opacity: 1 }}
-        >
-          {'>>'}
-        </motion.button>
-        <motion.button
-          id="prev"
-          className=" absolute top-[40%] text-green-900 bg-none border-none text-6xl font-mono font-bold opacity-80 transition-opacity z-10 left-[50px] max-sm:text-white max-sm:text-2xl max-sm:left-2"
-          onClick={() => setActive((prev) => (prev - 1 >= 0 ? prev - 1 : prev))}
-          whileHover={{ x: -10, color: '#00B2CA', opacity: 1 }}
-        >
-          {' '}
-          {'<<'}
-        </motion.button>
+        {active < items.length - 1 && (
+          <motion.button
+            id="next"
+            className=" absolute top-[40%] text-green-900 bg-none border-none text-6xl font-mono font-bold opacity-80 transition-opacity z-10 right-[50px] max-sm:text-white max-sm:text-2xl max-sm:right-2"
+            onClick={() =>
+              setActive((prev) => (prev + 1 < items.length ? prev + 1 : prev))
+            }
+            whileHover={{ x: 10, color: '#00B2CA', opacity: 1 }}
+          >
+            {'>>'}
+          </motion.button>
+        )}
+        {active > 0 && (
+          <motion.button
+            id="prev"
+            className=" absolute top-[40%] text-green-900 bg-none border-none text-6xl font-mono font-bold opacity-80 transition-opacity z-10 left-[50px] max-sm:text-white max-sm:text-2xl max-sm:left-2"
+            onClick={() => setActive((prev) => (prev - 1 >= 0 ? prev - 1 : prev))}
+            whileHover={{ x: -10, color: '#00B2CA', opacity: 1 }}
+          >
+            {' '}
+            {'<<'}
+          </motion.button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Issue : https://github.com/RamakrushnaBiswal/PlayCafe/issues/457
The "Prev" button is now conditionally rendered based on the active index. It will only appear if the active index is greater than 0 (i.e., not on the first item).
The "Next" button is conditionally rendered based on the active index. It will only appear if the active index is less than the last item (i.e., not on the last item).

**Screenshots**
<img width="1680" alt="Screenshot 2024-11-09 at 10 52 26 PM" src="https://github.com/user-attachments/assets/2ab14c0d-5d6a-4f2c-bb87-3b71ea9792f1">

<img width="1680" alt="Screenshot 2024-11-09 at 10 52 13 PM" src="https://github.com/user-attachments/assets/020479cf-8133-4ea6-95c7-24664a3492df">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved navigation in the Review Carousel by conditionally displaying "next" and "prev" buttons based on the active index, enhancing user experience.
  
- **Bug Fixes**
	- Prevented users from navigating beyond the bounds of carousel items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->